### PR TITLE
Fix PredictionSymbols First set call

### DIFF
--- a/source/ll1/ll1_parser.cpp
+++ b/source/ll1/ll1_parser.cpp
@@ -174,7 +174,7 @@ std::unordered_set<std::string>
 LL1Parser::PredictionSymbols(const std::string&              antecedent,
                              const std::vector<std::string>& consequent) {
     std::unordered_set<std::string> hd{};
-    First({consequent}, hd);
+    First(consequent, hd);
     if (!hd.contains(gr_.st_.EPSILON_)) {
         return hd;
     }


### PR DESCRIPTION
## Summary
- fix `PredictionSymbols` to pass consequent directly to `First`

## Testing
- `g++ -std=c++20 -Iinclude -Isource -Isource/ll1 -c source/ll1/ll1_parser.cpp -o /tmp/ll1_parser.o`
